### PR TITLE
Extend CodeRabbit config with architecture path instructions

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -18,13 +18,50 @@ reviews:
     - "!**/bin/**"
     - "!**/obj/**"
     - "!**/*.min.*"
-  # Steer the review with this repo's architecture rules.
+    - "!infra/db_schema.sql"  # pg_dump output — reviewed as a whole, not line-by-line
+    - "!infra/db_data.sql"    # seed/reference data dump
+  # Steer the review with this repo's Clean Architecture / DDD / CQRS rules.
   path_instructions:
     - path: "src/Reveries.Domain/**"
       instructions: >-
-        Domain layer must not depend on Application, Infrastructure, or any
-        ORM/EF types. Flag framework or outer-layer references. Prefer methods
-        that preserve invariants over public setters.
+        Domain layer must depend on nothing outside itself — flag any reference
+        to Application, Infrastructure, Api, or ORM/EF/framework types. Aggregates
+        expose two static factories: Create(...) is the validating/normalizing
+        entry point for new data and must throw meaningful domain exceptions on
+        broken invariants; Reconstitute(...) rehydrates already-persisted data and
+        must NOT re-validate. Flag validation or normalization added to the
+        Reconstitute path, and flag public setters where a method that preserves
+        invariants would be more appropriate. Prefer value objects and
+        strongly-typed IDs over primitives.
+    - path: "src/Reveries.Application/**"
+      instructions: >-
+        Use cases are vertical slices per aggregate (Commands/, Queries/,
+        Interfaces/, Services/, Mappers/, Models/). CQRS uses the
+        martinothamar/Mediator source generator (compile-time) — this is NOT
+        MediatR; flag MediatR usages or handler shapes that assume it. This layer
+        DEFINES the interfaces (repositories, integrations, cache) that outer
+        layers implement — it must not depend on Infrastructure or Api. It may
+        depend only on Domain.
+    - path: "src/Reveries.Api/Controllers/**"
+      instructions: >-
+        Controllers must stay thin: translate the incoming Contracts request into
+        a Mediator command/query and return the result — no business logic. Follow
+        the existing action shape (ActionResult<TResponse>, a CancellationToken ct
+        parameter, dispatch via IMediator). Flag business logic, data access, or
+        domain types leaking into the controller.
+    - path: "src/Reveries.Contracts/**"
+      instructions: >-
+        Request/response DTOs for the API boundary only. Domain types must never
+        cross the API boundary directly — flag any Domain type exposed here.
+        Mapping to/from these DTOs belongs in Reveries.Api/Mappers.
+    - path: "src/Reveries.Infrastructure.Postgresql/Repositories/**"
+      instructions: >-
+        Repositories use Dapper with hand-written SQL — there is no ORM migration
+        framework. If a change alters the schema (new/changed columns or tables),
+        flag that infra/db_schema.sql must be updated by hand to match, and that
+        the write should be exposed through IUnitOfWork. Multi-table writes must
+        run inside a transaction via BeginTransactionAsync(ct) so they commit or
+        roll back together.
     - path: "tests/**"
       instructions: >-
         Test project — focus on missing edge cases and clarity. Do not nitpick


### PR DESCRIPTION
Add path-scoped review instructions enforcing the repo's Clean Architecture / DDD / CQRS conventions: domain purity and Create vs Reconstitute, martinothamar/Mediator (not MediatR) in Application, thin controllers, Contracts-only DTOs at the API boundary, and Dapper/SQL + db_schema.sql upkeep in Postgresql repositories. Exclude the pg_dump SQL files from line-by-line review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded code review guidance with layer-specific architectural rules.
  * Added guidance for dependency boundaries, factories, CQRS, DTOs, SQL repositories, schema synchronization, unit-of-work usage, and transactions.
  * Excluded database dump files from review analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->